### PR TITLE
Remove duplicated lines starting opWrapper thread

### DIFF
--- a/src/openpose_ros_node.cpp
+++ b/src/openpose_ros_node.cpp
@@ -99,9 +99,6 @@ int openPoseROS()
     op::log("Starting thread(s)", op::Priority::High);
     opWrapper.start();
 
-    op::log("Starting thread(s)", op::Priority::High);
-    opWrapper.start();
-
     // OpenPose processing
     openpose_ros::OpenPoseROSIO openPoseROSIO(FLAGS_camera_topic, FLAGS_openpose_output_topic);
     bool userWantsToExit = false;


### PR DESCRIPTION
Fixes runtime error as per issue #5. 